### PR TITLE
Selected object 메모리에 동시에 접근할때의 데이터 구분 문제

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -272,6 +272,187 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1480192654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1480192657}
+  - component: {fileID: 1480192656}
+  - component: {fileID: 1480192655}
+  m_Layer: 0
+  m_Name: Circle (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1480192655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480192654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfd251ef5901746e39de2e5d20527fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inputs:
+  - {fileID: 1683245426}
+  - {fileID: 1529923382}
+  outPortCount: 0
+--- !u!212 &1480192656
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480192654}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: ebe73ca9363db456bacf42c025bb4847, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1480192657
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480192654}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.2, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1529923382
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1529923384}
+  - component: {fileID: 1529923383}
+  m_Layer: 0
+  m_Name: Square (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1529923383
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1529923382}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1529923384
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1529923382}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.497, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1683245426
 GameObject:
   m_ObjectHideFlags: 0
@@ -352,7 +533,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1910263446
 GameObject:
@@ -434,7 +615,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2143169810
 GameObject:
@@ -467,8 +648,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   inputs:
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 1910263446}
+  - {fileID: 1529923382}
   outPortCount: 0
 --- !u!212 &2143169812
 SpriteRenderer:

--- a/Assets/Scripts/ConnectData.cs
+++ b/Assets/Scripts/ConnectData.cs
@@ -5,98 +5,60 @@ using UnityEngine;
 
 namespace ConnectData
 {
-    public class PortInfo
-    //public struct PortInfo
+    public class WindowInfo
     {
-        private readonly int portID;
-        private bool open;
-        private GameObject selectedObj;
+        private readonly int id;
+        public bool open { get; set; }
+        public GameObject selectedObj { get; set; }
 
-        public PortInfo(int i)
+        public WindowInfo(int i)
         {
-            this.portID = i;
+            this.id = i;
             this.open = false;
             this.selectedObj = null;
         }
 
-        public bool Open() { this.open = true; return this.open; }
-
-        public bool Close() => this.open = false;
-
-        public bool Status() => this.open;
-
-        public GameObject Connect(GameObject value) => this.selectedObj = value;
-
-        public GameObject GetObject() => this.selectedObj;
-
-        public GameObject DisConnect() => this.selectedObj = null;
-
         public override string ToString()
         {
-            return $"port:{portID}, open:{open}, selectedObj:{selectedObj}";
+            return $"window:{id}, open:{open}, selectedObj:{selectedObj}";
         }
     }
 
     public class WindowCache
     {
-        private Dictionary<GameObject, Dictionary<int, PortInfo>> data;
+        private Dictionary<int, WindowInfo> data;
 
         public WindowCache()
         {
-            data = new Dictionary<GameObject, Dictionary<int, PortInfo>>();
+            data = new Dictionary<int, WindowInfo>();
         }
 
         ~WindowCache()
         {
-            data.Clear();
+            data = null;
         }
 
-        private Dictionary<int, PortInfo> GetGateData(GameObject target)
+        public WindowInfo AddWindowCache(int id)
         {
-            if (!data.ContainsKey(target))
+            if (!data.ContainsKey(id))
             {
-                data.Add(target, new Dictionary<int, PortInfo>());
+                data.Add(id, new WindowInfo(id));
             }
-            return data[target];
+            return data[id];
         }
 
-        private void DelGateData(GameObject target)
+        public void DelWindowCache(int id)
         {
-            if (data.ContainsKey(target))
+            if (data.ContainsKey(id))
             {
-                data.Remove(target);
-            }
-        }
-
-        public PortInfo AddPortCacheToGate(GameObject target, int index)
-        {
-            Dictionary<int, PortInfo> gate = GetGateData(target);
-
-            if (!gate.ContainsKey(index))
-            {
-                gate.Add(index, new PortInfo(index));
-            }
-            return gate[index];
-        }
-
-        public void DelPortCacheFromGate(GameObject target, int index)
-        {
-            if (data.ContainsKey(target))
-            {
-                if (data[target].ContainsKey(index))
-                    data[target].Remove(index);
-                if (data[target].Count == 0)
-                {
-                    data[target].Clear();
-                    DelGateData(target);
-                }
+                data.Remove(id);
             }
         }
 
-        public PortInfo this[GameObject target, int index]
+        public WindowInfo this[int id]
         {
-            get { return data[target][index]; }
-            set { data[target][index] = value; }
+            get { return data[id]; }
+            set { data[id] = value; }
         }
     }
 }

--- a/Assets/Scripts/ConnectData.cs
+++ b/Assets/Scripts/ConnectData.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 namespace ConnectData
 {
     public class PortInfo
+    //public struct PortInfo
     {
         private readonly int portID;
         private bool open;
@@ -72,7 +73,9 @@ namespace ConnectData
             Dictionary<int, PortInfo> gate = GetGateData(target);
 
             if (!gate.ContainsKey(index))
+            {
                 gate.Add(index, new PortInfo(index));
+            }
             return gate[index];
         }
 

--- a/Assets/Scripts/ConnectData.cs
+++ b/Assets/Scripts/ConnectData.cs
@@ -1,0 +1,99 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using UnityEngine;
+
+namespace ConnectData
+{
+    public class PortInfo
+    {
+        private readonly int portID;
+        private bool open;
+        private GameObject selectedObj;
+
+        public PortInfo(int i)
+        {
+            this.portID = i;
+            this.open = false;
+            this.selectedObj = null;
+        }
+
+        public bool Open() { this.open = true; return this.open; }
+
+        public bool Close() => this.open = false;
+
+        public bool Status() => this.open;
+
+        public GameObject Connect(GameObject value) => this.selectedObj = value;
+
+        public GameObject GetObject() => this.selectedObj;
+
+        public GameObject DisConnect() => this.selectedObj = null;
+
+        public override string ToString()
+        {
+            return $"port:{portID}, open:{open}, selectedObj:{selectedObj}";
+        }
+    }
+
+    public class WindowCache
+    {
+        private Dictionary<GameObject, Dictionary<int, PortInfo>> data;
+
+        public WindowCache()
+        {
+            data = new Dictionary<GameObject, Dictionary<int, PortInfo>>();
+        }
+
+        ~WindowCache()
+        {
+            data.Clear();
+        }
+
+        private Dictionary<int, PortInfo> GetGateData(GameObject target)
+        {
+            if (!data.ContainsKey(target))
+            {
+                data.Add(target, new Dictionary<int, PortInfo>());
+            }
+            return data[target];
+        }
+
+        private void DelGateData(GameObject target)
+        {
+            if (data.ContainsKey(target))
+            {
+                data.Remove(target);
+            }
+        }
+
+        public PortInfo AddPortCacheToGate(GameObject target, int index)
+        {
+            Dictionary<int, PortInfo> gate = GetGateData(target);
+
+            if (!gate.ContainsKey(index))
+                gate.Add(index, new PortInfo(index));
+            return gate[index];
+        }
+
+        public void DelPortCacheFromGate(GameObject target, int index)
+        {
+            if (data.ContainsKey(target))
+            {
+                if (data[target].ContainsKey(index))
+                    data[target].Remove(index);
+                if (data[target].Count == 0)
+                {
+                    data[target].Clear();
+                    DelGateData(target);
+                }
+            }
+        }
+
+        public PortInfo this[GameObject target, int index]
+        {
+            get { return data[target][index]; }
+            set { data[target][index] = value; }
+        }
+    }
+}

--- a/Assets/Scripts/ConnectData.cs.meta
+++ b/Assets/Scripts/ConnectData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d61ba3db7483a4c2e95da9cbb653536e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gate.cs
+++ b/Assets/Scripts/Gate.cs
@@ -1,6 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 using Types;
 

--- a/Assets/Scripts/Gate.cs
+++ b/Assets/Scripts/Gate.cs
@@ -6,32 +6,15 @@ using Types;
 
 public class Gate : MonoBehaviour
 {
-    public GameObject[] inputs = null;
-
-    public int inPortCount
-    {
-        get => inputs.Length;
-        set
-        {
-            if (inputs == null)
-                inputs = new GameObject[value];
-            else
-            {
-                GameObject[] tmp = new GameObject[value];
-                for (int i = 0; i < inputs.Length && i < value; i++)
-                {
-                    tmp[i] = inputs[i];
-                }
-                inputs = tmp;
-            }
-        }
-    }
-    public int outPortCount = 0;
+    public GameObject[]
+        inputs = null,
+        outputs = null;
+    
+    public GateType gateType { get; set; }
     
     private BitArray outBit { get; set; }
     private BitArray[] inBit;
     
-    private GateType gateType { get; set; }
 
     // Start is called before the first frame update
     private void Start()
@@ -47,12 +30,12 @@ public class Gate : MonoBehaviour
             if (inputs[i] != null)
                 inBit[i] = inputs[i].GetComponent<Gate>().outBit;
         }
-        outBit = gateAction(inBit);
+        outBit = gateAction(inBit, gateType);
     }
 
-    private BitArray gateAction(BitArray[] data)
+    private BitArray gateAction(BitArray[] data, GateType type = GateType.Not)
     {
-        switch (gateType)
+        switch (type)
         {
             case GateType.And:
                 {

--- a/Assets/Scripts/Gate.cs
+++ b/Assets/Scripts/Gate.cs
@@ -12,19 +12,19 @@ public class Gate : MonoBehaviour
     {
         get => inputs.Length;
         set
-	    {
+        {
             if (inputs == null)
                 inputs = new GameObject[value];
             else
-	        {
+            {
                 GameObject[] tmp = new GameObject[value];
-                for(int i = 0; i < inputs.Length && i < value; i++)
-		        {
+                for (int i = 0; i < inputs.Length && i < value; i++)
+                {
                     tmp[i] = inputs[i];
-		        }
+                }
                 inputs = tmp;
-	        }
-	    }
+            }
+        }
     }
     public int outPortCount = 0;
     
@@ -32,28 +32,28 @@ public class Gate : MonoBehaviour
     private BitArray[] inBit;
     
     private GateType gateType { get; set; }
-    
+
     // Start is called before the first frame update
     private void Start()
     {
         //initialize inBit;
         inBit = new BitArray[inputs.Length];
     }
-    
+
     private void FixedUpdate()
     {
         for (int i = 0; i < inputs.Length; i++)
-	    {
+        {
             if (inputs[i] != null)
                 inBit[i] = inputs[i].GetComponent<Gate>().outBit;
-	    }
+        }
         outBit = gateAction(inBit);
     }
 
     private BitArray gateAction(BitArray[] data)
     {
         switch (gateType)
-	    {
+        {
             case GateType.And:
                 {
                     int i = 0, j = i + 1;
@@ -92,7 +92,7 @@ public class Gate : MonoBehaviour
                 }
             default:
                 break;
-	    }
+        }
         return null;
     }
 }

--- a/Assets/editor/ConnectWindow.cs
+++ b/Assets/editor/ConnectWindow.cs
@@ -2,11 +2,11 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
-using Connect;
+using ConnectData;
 
 public class ConnectWindow : EditorWindow
 {
-    public static WindowData data = new WindowData();
+    public static WindowCache cache = new WindowCache();
     
     private GameObject target;
     private int index;
@@ -21,8 +21,7 @@ public class ConnectWindow : EditorWindow
         window.target = target;
         window.index = index;
 
-        data.AddData(index);
-        data.SetData(index, true); //set status data open.
+        cache.AddPortCacheToGate(target, index).Open();
 
         window.minSize = new Vector2(100, 100);
         GUIContent titleContent = new GUIContent(target.name + "/port" + index.ToString());
@@ -31,14 +30,11 @@ public class ConnectWindow : EditorWindow
         window.Show();
     }
 
-    public static GameObject getConnectObjInfo(int index) { return data.GetObj(index); }
+    public static GameObject getConnectObjInfo(GameObject obj, int i) => cache[obj, i].GetObject();
     
-    public static bool getWindowStatusInfo(int index) { return data.GetStatus(index); }
+    public static bool getWindowStatusInfo(GameObject obj, int i) => cache[obj, i].Status();
 
-    public static void cleanConnectWindowInfo(int index) 
-    {
-        data.ClearData(index);
-    }
+    public static void cleanConnectWindowInfo(GameObject obj, int i) => cache.DelPortCacheFromGate(obj, i);
 
     private void OnEnable()
     {
@@ -46,7 +42,7 @@ public class ConnectWindow : EditorWindow
 
     private void OnDestroy()
     {
-        data.SetData(index, false);
+        cache[target, index].Close();
     }
 
     private void OnGUI()
@@ -74,7 +70,7 @@ public class ConnectWindow : EditorWindow
             else
 	        {
                 warn = false;
-                data.SetData(index, tmp);
+                cache[target, index].Connect(tmp);
 			    this.Close(); 
 	        }
 	    }
@@ -93,63 +89,3 @@ public class ConnectWindow : EditorWindow
 	    EditorGUILayout.HelpBox("please select just one Object.", MessageType.Warning);
     }
 }
-
-namespace Connect
-{
-    public class WindowData
-    {
-        private Dictionary<int, bool> windowStatus;
-        private Dictionary<int, GameObject> selectionStatus;
-
-        public WindowData()
-        {
-            windowStatus = new Dictionary<int, bool>();
-            selectionStatus = new Dictionary<int, GameObject>();
-        }
-
-        public WindowData(ref WindowData prev)
-        {
-            windowStatus = prev.windowStatus;
-            selectionStatus = prev.selectionStatus;
-        }
-
-        ~WindowData()
-        {
-            windowStatus.Clear();
-            selectionStatus.Clear();
-        }
-
-        public void AddData(int index)
-        {
-            windowStatus.Add(index, false);
-            selectionStatus.Add(index, null);
-        }
-
-        public void ClearData(int index)
-        {
-            windowStatus.Remove(index);
-            selectionStatus.Remove(index);
-        }
-
-        public void SetData(int index, bool status)
-        {
-            windowStatus[index] = status;
-        }
-
-        public void SetData(int index, GameObject selected)
-        {
-            selectionStatus[index] = selected;
-        }
-
-        public void SetData(int index, bool status, GameObject selected)
-        {
-            windowStatus[index] = status;
-            selectionStatus[index] = selected;
-        }
-
-        public bool GetStatus(int index) => windowStatus[index];
-
-        public GameObject GetObj(int index) => selectionStatus[index];
-    }
-}
-

--- a/Assets/editor/ConnectWindow.cs
+++ b/Assets/editor/ConnectWindow.cs
@@ -6,43 +6,41 @@ using ConnectData;
 
 public class ConnectWindow : EditorWindow
 {
-    public static WindowCache cache = new WindowCache();
+    public static WindowCache cache { get; private set; } = new WindowCache();
+    private static int id = 0;
     
-    private GameObject target;
-    private int index;
+    private GameObject parentObj;
+    private int my_id;
 
     /// <summary>
-    /// init connect_window.
+    /// make ConnectWindow Instance and return WindowId.
     /// </summary>
-    public static void OpenWindow(GameObject target, int index)
+    public static int OpenWindow(GameObject parent)
     {
         ConnectWindow window = CreateInstance<ConnectWindow>();
 
-        window.target = target;
-        window.index = index;
+        window.parentObj = parent;
+        window.my_id = id;
 
-        cache.AddPortCacheToGate(target, index).Open();
+        Debug.Log("in:" + window.my_id.ToString());
 
         window.minSize = new Vector2(100, 100);
-        GUIContent titleContent = new GUIContent(target.name + "/port" + index.ToString());
+        GUIContent titleContent = new GUIContent(parent.name);
         window.titleContent = titleContent;
 
         window.Show();
+        return id++;
     }
-
-    public static GameObject getConnectObjInfo(GameObject obj, int i) => cache[obj, i].GetObject();
-    
-    public static bool getWindowStatusInfo(GameObject obj, int i) => cache[obj, i].Status();
-
-    public static void cleanConnectWindowInfo(GameObject obj, int i) => cache.DelPortCacheFromGate(obj, i);
 
     private void OnEnable()
     {
+        cache.AddWindowCache(id).open = true;
     }
 
     private void OnDestroy()
     {
-        cache[target, index].Close();
+        cache[my_id].open = false;
+        id--;
     }
 
     private void OnGUI()
@@ -57,7 +55,7 @@ public class ConnectWindow : EditorWindow
             
 	        foreach (GameObject obj in Selection.gameObjects)
 	        {
-                if (obj != target)
+                if (obj != parentObj)
                 {
 		            tmp = obj;
 		            num++;
@@ -70,11 +68,10 @@ public class ConnectWindow : EditorWindow
             else
 	        {
                 warn = false;
-                cache[target, index].Connect(tmp);
-			    this.Close(); 
+                cache[my_id].selectedObj = tmp;
+			    this.Close();
 	        }
 	    }
-        
 	    if (warn)
             DrawWarnMessage();
     }

--- a/Assets/editor/ConnectWindow.cs
+++ b/Assets/editor/ConnectWindow.cs
@@ -15,7 +15,8 @@ public class ConnectWindow : EditorWindow
     /// </summary>
     public static void OpenWindow(GameObject target)
     {
-        ConnectWindow window = GetWindow<ConnectWindow>(typeof(ConnectWindow));
+        //ConnectWindow window = GetWindow<ConnectWindow>(typeof(ConnectWindow));
+        ConnectWindow window = CreateInstance<ConnectWindow>();
         window.minSize = new Vector2(100, 100);
         window.target = target;
         window.Show();

--- a/Assets/editor/EditorList.cs
+++ b/Assets/editor/EditorList.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using System;
+
+public static class EditorList
+{
+    public static void Show(SerializedProperty list, ButtonFunc buttonFunc, EditorListOption option = EditorListOption.Default)
+    {
+        bool
+            showListLabel = (option & EditorListOption.ListLabel) != 0,
+            showListSize = (option & EditorListOption.ListSize) != 0;
+
+        EditorGUILayout.BeginVertical("Box");
+
+        if (showListLabel)
+        {
+            EditorGUILayout.PropertyField(list, false);
+            EditorGUI.indentLevel++;
+        }
+        if (!showListLabel || list.isExpanded)
+        {
+            if (showListSize)
+                EditorGUILayout.PropertyField(list.FindPropertyRelative("Array.size"));
+            ShowElement(list, buttonFunc, option);
+        }
+        if (showListLabel)
+            EditorGUI.indentLevel--;
+
+        EditorGUILayout.EndVertical();
+    }
+
+    private static void ShowElement(SerializedProperty list, ButtonFunc buttonFunc = null, EditorListOption option = EditorListOption.Default)
+    {
+        bool showElement = (option & EditorListOption.ElementLabel) != 0;
+
+        for (int i = 0; i < list.arraySize; i++)
+        {
+            if (buttonFunc != null)
+                EditorGUILayout.BeginHorizontal();
+            if (showElement)
+                EditorGUILayout.PropertyField(list.GetArrayElementAtIndex(i), true);
+            else
+                EditorGUILayout.PropertyField(list.GetArrayElementAtIndex(i), GUIContent.none);
+            if (buttonFunc != null)
+            {
+                buttonFunc(list, i);
+                EditorGUILayout.EndHorizontal();
+            }
+        }
+    }
+
+    public delegate void ButtonFunc(SerializedProperty list, int index);
+}
+
+[Flags]
+public enum EditorListOption
+{
+    None = 0,
+    ListSize = 1,
+    ListLabel = 2,
+    ElementLabel = 4,
+    Default = ListSize | ListLabel | ElementLabel
+}

--- a/Assets/editor/EditorList.cs.meta
+++ b/Assets/editor/EditorList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18f9498547fd142999cae1c4d839363b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/editor/GateDesignerWindow.cs
+++ b/Assets/editor/GateDesignerWindow.cs
@@ -24,7 +24,7 @@ public class GateDesignerWindow : EditorWindow
     static MuxType muxType;
 
     public static GateType gateInfo { get => gateType; }
-    public static MuxType muxInfo { get => muxType;}
+    public static MuxType muxInfo { get => muxType; }
 
     static GateData gateData;
     static MuxData muxData;
@@ -37,7 +37,7 @@ public class GateDesignerWindow : EditorWindow
         window.Show();
     }
 
-    
+
     /// <summary>
     /// similar with Awake() and Start()
     /// </summary>
@@ -75,7 +75,7 @@ public class GateDesignerWindow : EditorWindow
     /// <summary>
     /// read Gate, Mux Objects from resources
     /// </summary>
-    void InitData() 
+    void InitData()
     {
         gateData = Resources.Load<GateData>("gateData/data/gate/gateData");
         muxData = Resources.Load<MuxData>("gateData/data/mux/muxData");
@@ -119,7 +119,7 @@ public class GateDesignerWindow : EditorWindow
     /// <summary>
     /// draw contents of header
     /// </summary>
-    void DrawHeader() 
+    void DrawHeader()
     {
         //GUILayout.BeginArea(headerSection);
         GUILayout.BeginVertical();
@@ -135,8 +135,8 @@ public class GateDesignerWindow : EditorWindow
     {
         //GUILayout.BeginArea(gateSection);
         GUILayout.BeginVertical("Box");
-        
-	    GUILayout.Label("Gate", EditorStyles.boldLabel);
+
+        GUILayout.Label("Gate", EditorStyles.boldLabel);
         EditorGUILayout.Space();
         //GUILayout.FlexibleSpace();
 
@@ -147,9 +147,9 @@ public class GateDesignerWindow : EditorWindow
         EditorGUILayout.Space();
 
         if (GUILayout.Button("Create"))
-	    {
+        {
             switch (gateType)
-	        {
+            {
                 case GateType.Not:
                     Instantiate<GameObject>(gateData.notObject);
                     break;
@@ -164,8 +164,8 @@ public class GateDesignerWindow : EditorWindow
                     break;
                 default:
                     break;
-	        }
-	    }
+            }
+        }
 
         //GUILayout.EndArea();
         GUILayout.EndVertical();
@@ -177,8 +177,8 @@ public class GateDesignerWindow : EditorWindow
     {
         //GUILayout.BeginArea(muxSection);
         GUILayout.BeginVertical("Box");
-        
-	    GUILayout.Label("Multiplexor", EditorStyles.boldLabel);
+
+        GUILayout.Label("Multiplexor", EditorStyles.boldLabel);
         EditorGUILayout.Space();
 
         GUILayout.BeginHorizontal();
@@ -186,11 +186,11 @@ public class GateDesignerWindow : EditorWindow
         muxType = (MuxType)EditorGUILayout.EnumPopup(muxType);
         GUILayout.EndHorizontal();
         EditorGUILayout.Space();
-        
+
         if (GUILayout.Button("Create"))
-	    {
+        {
             switch (muxType)
-	        {
+            {
                 case MuxType.Mux:
                     Instantiate<GameObject>(muxData.muxObject);
                     break;
@@ -199,8 +199,8 @@ public class GateDesignerWindow : EditorWindow
                     break;
                 default:
                     break;
-	        }
-	    }
+            }
+        }
 
         //GUILayout.EndArea();
         GUILayout.EndVertical();

--- a/Assets/editor/GateEditor.cs
+++ b/Assets/editor/GateEditor.cs
@@ -1,7 +1,5 @@
 using UnityEngine;
 using UnityEditor;
-using TMPro.EditorUtilities;
-using System.Collections;
 
 [CustomEditor(typeof(Gate))]
 public class GateEditor : Editor
@@ -27,10 +25,10 @@ public class GateEditor : Editor
 
         origin.gateType = (Types.GateType)EditorGUILayout.EnumPopup(origin.gateType);
 
-        EditorGUILayout.BeginHorizontal();
-        EditorList.Show(serializedObject.FindProperty("inputs"), null);
-        EditorList.Show(serializedObject.FindProperty("outputs"), null);
-        EditorGUILayout.EndHorizontal();
+        //EditorGUILayout.BeginHorizontal();
+        EditorList.Show(serializedObject.FindProperty("inputs"), InputButton);
+        EditorList.Show(serializedObject.FindProperty("outputs"), OutputButton);
+        //EditorGUILayout.EndHorizontal();
     }
 
     void DrawGateHeader()
@@ -39,26 +37,39 @@ public class GateEditor : Editor
         EditorGUILayout.Space();
     }
 
-    void gateEditorButton(SerializedProperty list, int index)
+    void InputButton(SerializedProperty list, int index)
     {
+        if (origin.inputs[index] == null)
+        {
+            if (GUILayout.Button("connect"))
+            {
+                ConnectWindow.Connect(origin.gameObject, (newValue) => { origin.inputs[index] = newValue; });
+            }
+        }
+        else
+        {
+            if (GUILayout.Button("disconnect"))
+            {
+                origin.inputs[index] = null;
+            }
+        }
     }
 
-    delegate void setObjmethod(GameObject to);
-
-    /// <summary>
-    /// Open Connected window and wait it closed, get result.
-    /// </summary>
-    /// <param name="portID">ID that you want to connect.</param>
-    /// <returns></returns>
-    IEnumerator Connect(setObjmethod setObj)
+    void OutputButton(SerializedProperty list, int index)
     {
-        int id = ConnectWindow.OpenWindow(origin.gameObject);
-        while (ConnectWindow.cache[id].open)
+        if (origin.outputs[index] == null)
         {
-            yield return null;
+            if (GUILayout.Button("connect"))
+            {
+                ConnectWindow.Connect(origin.gameObject, (newValue) => { origin.outputs[index] = newValue; });
+            }
         }
-        //origin.inputs[portID] = ConnectWindow.cache[id].selectedObj;
-        setObj.Invoke(ConnectWindow.cache[id].selectedObj);
-        ConnectWindow.cache.DelWindowCache(id);
+        else
+        {
+            if (GUILayout.Button("disconnect"))
+            {
+                origin.outputs[index] = null;
+            }
+        }
     }
 }

--- a/Assets/editor/GateEditor.cs
+++ b/Assets/editor/GateEditor.cs
@@ -86,11 +86,11 @@ public class GateEditor : Editor
     IEnumerator Connect(int portID)
     {
         ConnectWindow.OpenWindow(origin.gameObject, portID);
-        while (ConnectWindow.getWindowStatusInfo(portID))
+        while (ConnectWindow.getWindowStatusInfo(origin.gameObject, portID))
         {
             yield return null;
         }
-        origin.inputs[portID] = ConnectWindow.getConnectObjInfo(portID);
-        ConnectWindow.cleanConnectWindowInfo(portID);
+        origin.inputs[portID] = ConnectWindow.getConnectObjInfo(origin.gameObject, portID);
+        ConnectWindow.cleanConnectWindowInfo(origin.gameObject, portID);
     }
 }

--- a/Assets/editor/GateEditor.cs
+++ b/Assets/editor/GateEditor.cs
@@ -9,7 +9,7 @@ using System.Collections;
 public class GateEditor : Editor
 {
     Gate origin;
-    
+
     public override void OnInspectorGUI()
     {
         //base.OnInspectorGUI();
@@ -30,15 +30,15 @@ public class GateEditor : Editor
 
         GUILayout.BeginVertical("Box");
         DrawInSection();
-        GUILayout.EndVertical(); 
-	    
-	    GUILayout.BeginVertical("Box");
+        GUILayout.EndVertical();
+
+        GUILayout.BeginVertical("Box");
         DrawOutSection();
         GUILayout.EndVertical();
 
         GUILayout.EndHorizontal();
-        
-	    GUILayout.EndVertical();
+
+        GUILayout.EndVertical();
     }
 
     void DrawGateHeader()
@@ -49,7 +49,7 @@ public class GateEditor : Editor
 
     void DrawInSection()
     {
-	    GUILayout.Label("In", EditorStyles.boldLabel);
+        GUILayout.Label("In", EditorStyles.boldLabel);
         origin.inPortCount = EditorGUILayout.IntSlider(origin.inPortCount, 0, 10);
 
         for (int i = 0; i < origin.inPortCount; i++)
@@ -85,11 +85,12 @@ public class GateEditor : Editor
     /// <returns></returns>
     IEnumerator Connect(int portID)
     {
-        ConnectWindow.OpenWindow(origin.gameObject);
-        while (ConnectWindow.open)
-	    {
+        ConnectWindow.OpenWindow(origin.gameObject, portID);
+        while (ConnectWindow.getWindowStatusInfo(portID))
+        {
             yield return null;
-	    }
-	    origin.inputs[portID] = ConnectWindow.selectedObject;
+        }
+        origin.inputs[portID] = ConnectWindow.getConnectObjInfo(portID);
+        ConnectWindow.cleanConnectWindowInfo(portID);
     }
 }

--- a/Assets/editor/GateEditor.cs
+++ b/Assets/editor/GateEditor.cs
@@ -60,7 +60,6 @@ public class GateEditor : Editor
                 GUILayout.Label("port" + i.ToString());
                 if (GUILayout.Button("Connect"))
                 {
-				    //ConnectWindow.OpenWindow(origin.gameObject);
                     TMP_EditorCoroutine.StartCoroutine(Connect(i));
                 }
             }
@@ -87,13 +86,10 @@ public class GateEditor : Editor
     IEnumerator Connect(int portID)
     {
         ConnectWindow.OpenWindow(origin.gameObject);
-        //yield return new WaitWhile(()=>ConnectWindow.open);
-        Debug.Log("wait start");
         while (ConnectWindow.open)
 	    {
             yield return null;
 	    }
-        Debug.Log("wait end");
 	    origin.inputs[portID] = ConnectWindow.selectedObject;
     }
 }


### PR DESCRIPTION
ConnectWindow 창이 닫힐 때, static 메모리에 선택한 오브젝트를 저장해두는 방법으로 선택한 오브젝트를 가져왔었다. 하지만 이 방법은 한번에 여러 창이 열려있을때, 창마다 선택한 오브젝트가 다를 경우 원하는 대로 기능이 작동하지 않았다. 그래서 창마다 고유의 portIndex가 있었기 때문에 portIndex를 key값으로 가지는 Dictionary를 만들어 문제를 해결하였다.