### PR TITLE
 make gate Model

### DIFF
--- a/Assets/Scripts/BaseModel.cs
+++ b/Assets/Scripts/BaseModel.cs
@@ -1,0 +1,142 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using System;
+
+namespace BaseModel
+{
+    public class Port
+    {
+        public bool[] Bit { get; set; }
+
+        public Port From
+        {
+            get => _from;
+            private set
+            {
+                _from = value;
+                value.To = _from;
+            }
+        }
+        public Port To
+        {
+            get => _to;
+            private set
+            {
+                _to = value;
+                value.From = _to;
+            }
+        }
+
+        private Port _from;
+        private Port _to;
+
+        public void Send(Port to)
+        {
+            this.To = to;
+            to.Bit = this.Bit;
+        }
+
+        public void Send(Port to, bool[] bit)
+        {
+            this.To = to;
+            this.Bit = bit;
+            to.Bit = this.Bit;
+        }
+
+        public void Recept(Port from)
+        {
+            this.From = from;
+            this.Bit = from.Bit;
+        }
+
+        public void Recept(bool[] bit)
+        {
+            this.Bit = bit;
+        }
+
+        public Port(int bitSize, Dir option)
+        {
+            Bit = new bool[bitSize];
+            for (int i = 0; i < bitSize; i++)
+            {
+                Bit[i] = false;
+            }
+
+            switch (option)
+            {
+                case Dir.enter:
+                    _to = this;
+                    _from = null;
+                    break;
+                case Dir.exit:
+                    _from = this;
+                    _to = null;
+                    break;
+            }
+        }
+        [Flags]
+        public enum Dir
+        {
+            enter,
+            exit
+        }
+    }
+
+    public static class GateModel
+    {
+        public static bool[] AndGate(bool[] a, bool[] b)
+        {
+            if (a.Length != b.Length)
+                return null;
+
+            bool[] outBit = new bool[a.Length];
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                outBit[i] = a[i] & b[i];
+            }
+            return outBit;
+        }
+
+        public static bool[] OrGate(bool[] a, bool[] b)
+        {
+            if (a.Length != b.Length)
+                return null;
+
+            bool[] outBit = new bool[a.Length];
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                outBit[i] = a[i] | b[i];
+            }
+            return outBit;
+        }
+
+        public static bool[] XorGate(bool[] a, bool[] b)
+        {
+            if (a.Length != b.Length)
+                return null;
+
+            bool[] outBit = new bool[a.Length];
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                outBit[i] = a[i] ^ b[i];
+            }
+            return outBit;
+        }
+
+        public static bool[] NotGate(bool[] a)
+        {
+            bool[] outBit = new bool[a.Length];
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                outBit[i] = !a[i];
+            }
+            return outBit;
+        }
+    }
+}

--- a/Assets/Scripts/BaseModel.cs.meta
+++ b/Assets/Scripts/BaseModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17fdc2250d08f423eb4afbe0f0e3f6f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BaseObject.cs
+++ b/Assets/Scripts/BaseObject.cs
@@ -1,0 +1,123 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using BaseModel;
+
+public class BaseObject : MonoBehaviour
+{
+    /*
+    public List<Port> Inputs { get; private set; }
+    public List<Port> Sels { get; private set; }
+    public List<Port> Outputs { get; private set; }
+    */
+    public List<Port> Inputs;
+    public List<Port> Sels;
+    public List<Port> Outputs;
+
+    public int InputSize
+    {
+        get
+        {
+            if (Inputs == null)
+                Inputs = new List<Port>();
+            return Inputs.Count;
+        }
+        set
+        {
+            if (value > Inputs.Count)
+            {
+                for (int i = Inputs.Count; i < value; i++)
+                {
+                    Inputs.Add(new Port(i, Port.Dir.enter));
+                }
+            }
+            else if (value < Inputs.Count)
+            {
+                Inputs.RemoveRange(value, Inputs.Count - value);
+            }
+        }
+    }
+    
+    public int SelSize
+    {
+        get
+        {
+            if (Sels == null)
+                Sels = new List<Port>();
+            return Sels.Count;
+        }
+        set
+        {
+            if (value > Sels.Count)
+            {
+                for (int i = Sels.Count; i < value; i++)
+                {
+                    Inputs.Add(new Port(i, Port.Dir.sel));
+                }
+            }
+            else if (value < Sels.Count)
+            {
+                Inputs.RemoveRange(value, Sels.Count - value);
+            }
+        }
+    }
+    
+    public int OutputSize
+    {
+        get
+        {
+            if (Outputs == null)
+                Outputs = new List<Port>();
+            return Outputs.Count;
+        }
+        set
+        {
+            if (value > Outputs.Count)
+            {
+                for (int i = Outputs.Count; i < value; i++)
+                {
+                    Outputs.Add(new Port(i, Port.Dir.exit));
+                }
+            }
+            else if (value < Outputs.Count)
+            {
+                Outputs.RemoveRange(value, Outputs.Count - value);
+            }
+        }
+    }
+
+    protected bool[] inputBit;
+    protected bool[] selBit;
+    protected bool[] outputBit;
+
+    protected virtual void Start()
+    {
+        inputBit = new bool[Inputs.Count];
+        selBit = new bool[Sels.Count];
+        outputBit = new bool[Outputs.Count];
+    }
+
+    void FixedUpdate()
+    {
+        for (int i = 0; i < InputSize; i++)
+        {
+            Inputs[i].Update();
+            inputBit[i] = Inputs[i].Bit;
+        }
+        for (int i = 0; i < SelSize; i++)
+        {
+            Sels[i].Update();
+            selBit[i] = Sels[i].Bit;
+        }
+        Function();
+        for (int i = 0; i < OutputSize; i++)
+        {
+            Outputs[i].Bit = outputBit[i];
+            Outputs[i].Update();
+        }
+    }
+
+    protected virtual void Function()
+    {
+    }
+}

--- a/Assets/Scripts/BaseObject.cs.meta
+++ b/Assets/Scripts/BaseObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13ec20e2361ff4dba98cfa097c1baf27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Port.cs
+++ b/Assets/Scripts/Port.cs
@@ -1,0 +1,137 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using System;
+
+namespace BaseModel
+{
+    public class Port
+    {
+        public int index { get; private set; }
+        public bool Bit { get; set; } = false;
+        public Dir type { get; private set; }
+
+        public Port From
+        {
+            get => _from;
+            private set
+            {
+                _from = value;
+            }
+        }
+        public Port To
+        {
+            get => _to;
+            private set
+            {
+                _to = value;
+            }
+        }
+
+        private Port _from;
+        private Port _to;
+
+        public void ConnectTo(Port to)
+        {
+            this.To = to;
+            to.From = this;
+        }
+
+        public void ConnectFrom(Port from)
+        {
+            this.From = from;
+            from.To = this;
+        }
+
+        public void Disconnect()
+        {
+            if (type == Dir.exit)
+                this.To = null;
+            else
+                this.From = null;
+        }
+
+        public void Update()
+        {
+            switch (type)
+            {
+                case Dir.enter:
+                    if (_from != null)
+                        this.Bit = _from.Bit;
+                    break;
+                case Dir.exit:
+                    if (_to != null)
+                        To.Bit = this.Bit;
+                    break;
+                case Dir.sel:
+                    if (_from != null)
+                        this.Bit = _from.Bit;
+                    break;
+            }
+        }
+
+        public Port Connected()
+        {
+            switch (type)
+            {
+                case Dir.enter:
+                    return this._from;
+                case Dir.exit:
+                    return this._to;
+                case Dir.sel:
+                    return this._from;
+                default:
+                    return null;
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = "";
+            //return base.ToString();
+            switch (type)
+            {
+                case Dir.enter:
+                    name = "in";
+                    break;
+                case Dir.exit:
+                    name = "out";
+                    break;
+                case Dir.sel:
+                    name = "sel";
+                    break;
+            }
+            return (name + String.Format("[{0}]", this.index));
+        }
+
+        public Port(int index, Dir option)
+        {
+            this.index = index;
+            type = option;
+            switch (option)
+            {
+                case Dir.enter:
+                    _to = this;
+                    _from = null;
+                    break;
+                case Dir.exit:
+                    _from = this;
+                    _to = null;
+                    break;
+                case Dir.sel:
+                    _to = this;
+                    _from = null;
+                    break;
+            }
+        }
+
+        [Flags]
+        public enum Dir
+        {
+            enter,
+            exit,
+            sel
+        }
+    }
+}

--- a/Assets/Scripts/Port.cs.meta
+++ b/Assets/Scripts/Port.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17fdc2250d08f423eb4afbe0f0e3f6f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
mvc 모델에 대한 저번 조언을 바탕으로 monobehaviour을 상속받는 것이 controler, 데이터와 동작을 구현하는 것이 model이라 생각하고 gate와 Port의 model을 짜봤다. gate는 생각해보니 연산으로 존재하기 때문에, static class로 구현하였다. Port를 생각해봤을때, 그 안의 bit 정보, 그리고 행선지의 주소가 존재해야 한다고 생각하였고, Port의 종류가 입구Port, 출구Port 두가지로 존재한다고 판단하여 연산의 종류를 나누었다.